### PR TITLE
Potential fix for code scanning alert no. 34: Log entries created from user input

### DIFF
--- a/NetCoreAzureBlobServiceAPI/Services/FileManagementService.cs
+++ b/NetCoreAzureBlobServiceAPI/Services/FileManagementService.cs
@@ -79,7 +79,8 @@ namespace NetCoreAzureBlobServiceAPI.Services
             {
                 var blobs = await _blobStorageRepository.ListBlobsAsync(containerName);
                 var blobList = blobs.ToList();
-                _logger.LogInformation("Listed {BlobCount} blobs from container {ContainerName}", blobList.Count, containerName);
+                var safeContainerNameForLog = containerName.Replace("\r", string.Empty).Replace("\n", string.Empty);
+                _logger.LogInformation("Listed {BlobCount} blobs from container {ContainerName}", blobList.Count, safeContainerNameForLog);
                 return blobList;
             }
             catch (Exception ex) when (ex is not BlobStorageException)
@@ -110,7 +111,8 @@ namespace NetCoreAzureBlobServiceAPI.Services
             try
             {
                 var stream = await _blobStorageRepository.DownloadBlobAsync(containerName, blobName);
-                _logger.LogInformation("Blob {BlobName} downloaded successfully from container {ContainerName}", blobName, containerName);
+                var safeContainerNameForLog = containerName.Replace("\r", string.Empty).Replace("\n", string.Empty);
+                _logger.LogInformation("Blob {BlobName} downloaded successfully from container {ContainerName}", blobName, safeContainerNameForLog);
                 return stream;
             }
             catch (BlobNotFoundException)


### PR DESCRIPTION
### **User description**
Potential fix for [https://github.com/tomblanchard312/AzureBlobStorageAPI/security/code-scanning/34](https://github.com/tomblanchard312/AzureBlobStorageAPI/security/code-scanning/34)

In general, to fix log-forging issues, any user-controlled data that is written to logs should be sanitized to remove or neutralize characters that can break log structure (such as `\r`, `\n`, and other control characters). For plain text logs, a simple and effective approach is to strip `\r` and `\n` and optionally replace other control characters with safe placeholders. For HTML-rendered logs, HTML encoding should be applied before logging.

For this specific code, the problematic value is `containerName`, which is derived from `clientId` and then logged. The safest minimal change that preserves existing behavior is to sanitize `containerName` just for logging, while continuing to use the original `containerName` for actual storage operations. That way, we do not risk breaking any existing interaction with Azure Blob Storage or naming assumptions, and only adjust what is written to logs.

Concretely, in `FileManagementService.ListBlobsAsync`, we should introduce a sanitized version of `containerName` for the log call at line 82. Similarly, in `FileManagementService.DownloadBlobAsync`, we should sanitize `containerName` before logging it at line 113. Because we want to avoid changing functionality and to keep the fix simple and local, we can implement sanitization inline with `Replace("\r", "").Replace("\n", "")`, which does not require additional dependencies or imports. Only the logging calls need to be adjusted; the rest of the file can remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


___

### **PR Type**
Bug fix


___

### **Description**
- Sanitize `containerName` in log entries to prevent log forging

- Remove carriage return and newline characters before logging

- Apply sanitization in `ListBlobsAsync` and `DownloadBlobAsync` methods

- Preserve original `containerName` for actual storage operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User Input containerName"] --> B["Original containerName<br/>for Storage Operations"]
  A --> C["Sanitized containerName<br/>Remove \\r and \\n"]
  C --> D["Safe Log Entry"]
  B --> E["Azure Blob Storage"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FileManagementService.cs</strong><dd><code>Sanitize container name in logging calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NetCoreAzureBlobServiceAPI/Services/FileManagementService.cs

<ul><li>Added sanitization of <code>containerName</code> in <code>ListBlobsAsync</code> method by <br>removing <code>\r</code> and <code>\n</code> characters before logging<br> <li> Added sanitization of <code>containerName</code> in <code>DownloadBlobAsync</code> method by <br>removing <code>\r</code> and <code>\n</code> characters before logging<br> <li> Sanitization applied only to log statements, preserving original value <br>for storage operations<br> <li> Uses inline <code>Replace()</code> calls without additional dependencies</ul>


</details>


  </td>
  <td><a href="https://github.com/tomblanchard312/AzureBlobStorageAPI/pull/98/files#diff-e93785ea801207ac3ca8ea583e4dd47e112e37be1e81e0b716a333e069d78f63">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Mitigates log-forging by sanitizing user-derived values before logging.
> 
> - In `FileManagementService.ListBlobsAsync` and `DownloadBlobAsync`, log `containerName` via a sanitized `safeContainerNameForLog` that strips `\r` and `\n`
> - Only logging is affected; storage operations continue using the original `containerName`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04500cf19a311d08c564f1d989d415432006f6a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->