### PR TITLE
Potential fix for code scanning alert no. 41: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-build-test.yml
+++ b/.github/workflows/dotnet-build-test.yml
@@ -4,6 +4,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
### **User description**
Potential fix for [https://github.com/tomblanchard312/AzureBlobStorageAPI/security/code-scanning/41](https://github.com/tomblanchard312/AzureBlobStorageAPI/security/code-scanning/41)

In general, the fix is to explicitly declare the minimal `GITHUB_TOKEN` permissions this workflow needs. Since the jobs only check out code and run .NET restore/build/test, they only need read access to the repository contents. The simplest and safest fix is to add a root-level `permissions` block (so it applies to all jobs) with `contents: read`.

Concretely, in `.github/workflows/dotnet-build-test.yml`, add a `permissions:` section near the top of the file (after `name:` and/or `concurrency:` and before `on:`). Set it to:

```yaml
permissions:
  contents: read
```

This will apply to both `unit-tests` and `integration-tests` jobs, restricting the `GITHUB_TOKEN` to read-only repository contents while preserving all existing behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


___

### **PR Type**
Bug fix


___

### **Description**
- Add explicit minimal GITHUB_TOKEN permissions to workflow

- Restrict token to read-only repository contents access

- Resolve code scanning alert requiring permissions declaration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["dotnet-build-test.yml"] -- "add permissions block" --> B["contents: read"]
  B -- "restricts GITHUB_TOKEN" --> C["Read-only access"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dotnet-build-test.yml</strong><dd><code>Add explicit minimal GITHUB_TOKEN permissions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/dotnet-build-test.yml

<ul><li>Added root-level <code>permissions</code> block with <code>contents: read</code><br> <li> Positioned after <code>concurrency</code> section and before <code>on</code> trigger<br> <li> Applies minimal GITHUB_TOKEN permissions to all jobs<br> <li> Restricts token to read-only repository contents access</ul>


</details>


  </td>
  <td><a href="https://github.com/tomblanchard312/AzureBlobStorageAPI/pull/110/files#diff-384eb0506f8ca1ae0a186f686e6b76e71167a3805a4ed2f54b46735788a7773c">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Tightens CI security by explicitly setting minimal `GITHUB_TOKEN` permissions.
> 
> - Adds root-level `permissions` block with `contents: read` in `/.github/workflows/dotnet-build-test.yml`, applying to all jobs without altering build/test behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 796ff46cce086463aec28b8d3d99bc5b9e171ffd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->