### PR TITLE
Potential fix for code scanning alert no. 44: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/infra-validate.yml
+++ b/.github/workflows/infra-validate.yml
@@ -1,5 +1,7 @@
 # Validate Bicep code only: build and lint. No Azure login or credentials required.
 name: Infra validate
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
### **User description**
Potential fix for [https://github.com/tomblanchard312/AzureBlobStorageAPI/security/code-scanning/44](https://github.com/tomblanchard312/AzureBlobStorageAPI/security/code-scanning/44)

In general, fix this by explicitly defining a `permissions:` block specifying the minimal required `GITHUB_TOKEN` scopes. Because this workflow only checks out code and runs local validation commands, it only needs read access to repository contents.

The best single fix is to add a top-level `permissions:` block (at the workflow root, alongside `name:`, `concurrency:`, and `on:`) that restricts the token to `contents: read`. This applies to all jobs unless a job overrides it, and does not interfere with any current steps, since none require write access. Concretely, in `.github/workflows/infra-validate.yml`, insert:

```yaml
permissions:
  contents: read
```

after the `name: Infra validate` line (line 2). No additional imports, tools, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


___

### **PR Type**
Bug fix


___

### **Description**
- Add explicit permissions block to workflow

- Restrict GITHUB_TOKEN to read-only access

- Resolve code scanning alert about missing permissions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Workflow without permissions"] -- "Add permissions block" --> B["Workflow with contents read-only"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Security</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>infra-validate.yml</strong><dd><code>Add explicit read-only permissions to workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/infra-validate.yml

<ul><li>Added top-level <code>permissions:</code> block after workflow name<br> <li> Restricted GITHUB_TOKEN to <code>contents: read</code> scope<br> <li> Applies minimal required permissions to all jobs<br> <li> Resolves code scanning alert no. 44</ul>


</details>


  </td>
  <td><a href="https://github.com/tomblanchard312/AzureBlobStorageAPI/pull/117/files#diff-f35ebfb015e4253fe0b947665ab06c3e7b768c9a152a8f7f14aaf0a979724321">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only change that reduces token scope and does not modify application or infrastructure behavior.
> 
> **Overview**
> Updates the `Infra validate` GitHub Actions workflow to explicitly set minimal `GITHUB_TOKEN` permissions by adding `permissions: contents: read` at the workflow root, addressing code-scanning guidance for workflows without a permissions block.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d06b85b29207d4c200d167c6d36615c3fc16263. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->