### PR TITLE
Fix CI workflow trigger and integration test project path

### DIFF
--- a/.github/workflows/dotnet-build-test.yml
+++ b/.github/workflows/dotnet-build-test.yml
@@ -14,7 +14,7 @@ on:
       - '**/*.cs'
       - '**/*.csproj'
       - '**/*.sln'
-      - '.github/workflows/ci.yml'
+      - '.github/workflows/dotnet-build-test.yml'
   pull_request:
     branches: [ main ]
     paths:
@@ -63,7 +63,7 @@ jobs:
 
       - run: dotnet restore NetCoreAzureBlobServiceAPI.sln
       - run: dotnet build NetCoreAzureBlobServiceAPI.sln --no-restore --configuration Release
-      - run: dotnet test NetCoreAzureBlobServiceAPI.Tests/NetCoreAzureBlobServiceAPI.Tests. csproj \
+      - run: dotnet test NetCoreAzureBlobServiceAPI.Tests/NetCoreAzureBlobServiceAPI.Tests.csproj \
           --no-build --configuration Release \
           --filter "Category=Integration" \
           --logger "trx;LogFileName=TestResults.trx"


### PR DESCRIPTION
### Motivation
- Ensure the CI workflow is triggered for changes to its own file and that the integration tests run against the correct test project file to prevent GitHub Actions failures.

### Description
- Updated `.github/workflows/dotnet-build-test.yml` to change the `push.paths` entry from `'.github/workflows/ci.yml'` to the actual workflow file `'.github/workflows/dotnet-build-test.yml'` and removed an extra space in the integration test project path so the command uses `NetCoreAzureBlobServiceAPI.Tests/NetCoreAzureBlobServiceAPI.Tests.csproj`.

### Testing
- Verified the workflow diff with `git diff` and committed the change (succeeded); attempted to run `dotnet test` locally failed because `dotnet` is not installed in this environment; attempted to parse the workflow with `python` failed because `PyYAML` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e968cd0cb48321b57a1322b9107791)